### PR TITLE
Fix ruler variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="taurusgui-beamviewer",
-    version="0.12.5",
+    version="0.12.6",
     description="GUI for viewing YAG screens",
     author="Johan Forsberg",
     author_email="johan.forsberg@maxlab.lu.se",

--- a/src/tgconf_beamviewer/panels/beamviewerwidget.py
+++ b/src/tgconf_beamviewer/panels/beamviewerwidget.py
@@ -332,6 +332,13 @@ class BeamViewerImageWidget(TaurusWidget):
         if not self._ruler_dragged and evt_type in (PyTango.EventType.PERIODIC_EVENT,
                                                     PyTango.EventType.CHANGE_EVENT):
             self._ruler = json.loads(evt_data.value)
+            if "pos" not in self._ruler:
+                print "Initializing ruler for first time"
+                x1, y1 = self._ruler[0]
+                w, h = self._ruler[1]
+                self._ruler = {"angle": 0.0,
+                               "pos": [x1, y1],
+                               "size": [w, h]}
             self.ruler_trigger.emit()
 
     def update_ruler(self):


### PR DESCRIPTION
This fix issue #2.
It is necessary a dictionary with angle, pos and size when self._ruler is create for the first time, in order to match with "RectRoi" object from pyqtgraph (see handle_ruler) in [limabeam.py](https://github.com/MaxIV-KitsControls/app-maxiv-beamviewer/blob/81d232f7d75f8b9f829e71ee20c4f50a37f45856/src/tgconf_beamviewer/panels/limabeam.py#L492)